### PR TITLE
[FIX] 타이머에서 숫자 키패드 Enter가 동작하지 않는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "debate-timer-fe-win",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.1",
   "homepage": "./",
   "main": "./dist/main/main.js",
   "scripts": {

--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -32,7 +32,7 @@ export function useTimerHotkey(state: TimerPageLogics) {
      */
     const handleKeyDown = (event: KeyboardEvent) => {
       // 핫키로 쓸 키 목록
-      const keysToDisable = [
+      const keysToDisable = new Set([
         'Space',
         'ArrowLeft',
         'ArrowRight',

--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -7,7 +7,7 @@ import { TimerPageLogics } from './useTimerPageState';
  * - ArrowLeft/ArrowRight: 이전/다음 라운드 이동
  * - KeyR: 타이머 리셋
  * - KeyA/KeyL: 각각 찬/반 진영 타이머 활성화
- * - Enter: 진영 전환
+ * - Enter/NumpadEnter: 진영 전환
  */
 export function useTimerHotkey(state: TimerPageLogics) {
   const {
@@ -40,10 +40,11 @@ export function useTimerHotkey(state: TimerPageLogics) {
         'KeyA',
         'KeyL',
         'Enter',
-      ];
+        'NumpadEnter',
+      ]);
 
       // 핫키 입력시, 기본 동작(스크롤, 폼 전송 등) 막음
-      if (keysToDisable.includes(event.code)) {
+      if (keysToDisable.has(event.code)) {
         event.preventDefault();
       }
       // 입력 포커스 해제(특히 input/select 사용 중일 때)
@@ -112,6 +113,7 @@ export function useTimerHotkey(state: TimerPageLogics) {
           }
           break;
         case 'Enter':
+        case 'NumpadEnter':
           // 진영 전환
           switchCamp();
           break;


### PR DESCRIPTION
# 🚩 연관 이슈

closed #16 

# 📝 작업 내용
## 문제 상황
타이머에서 진영 전환은 Enter 키로 가능하지만, 숫자 키패드의 Enter 키는 인식하지 못하는 문제가 있었음

## 개선 사항
`useTimerHotkey` 훅이 `NumpadEnter`도 인식하도록 개선

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
동일한 PR이 [debate-timer-fe](https://github.com/debate-timer/debate-timer-fe) 저장소에서 승인되고 병합되었으므로, 이 저장소에서는 별도 PR 리뷰 없이 병합합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 숫자 키패드의 Enter(NumpadEnter) 키를 일반 Enter 키와 동일하게 타이머 캠프 전환 단축키로 사용할 수 있도록 개선했습니다.  
  * Enter 및 NumpadEnter 키 모두에서 기본 브라우저 동작이 차단됩니다.

* **기타**
  * 버전 정보가 1.0.1로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->