### PR TITLE
[DESIGN] 시간 총량제 타이머 제목 추가 및 해상도 제한 변경

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,9 +14,9 @@ function createWindow() {
   // Set window specs
   const mainWindow = new BrowserWindow({
     width: 1280,
-    height: 1080,
+    height: 864,
     minWidth: 1280,
-    minHeight: 1080,
+    minHeight: 864,
     icon: path.join(__dirname, '../renderer/icon.ico'), // Set the window icon
     webPreferences: {
       preload: path.join(__dirname, '../preload/preload.js'), // Path of preload script

--- a/src/page/TimerPage/components/TimeBasedTimerTitle.tsx
+++ b/src/page/TimerPage/components/TimeBasedTimerTitle.tsx
@@ -1,0 +1,71 @@
+import React, { PropsWithChildren, useId } from 'react';
+
+interface TimeBasedTimerTitleProps extends PropsWithChildren {
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export default function TimeBasedTimerTitle({
+  children,
+  width = 320,
+  height = 60,
+  className,
+}: TimeBasedTimerTitleProps) {
+  return (
+    <div
+      className={`relative inline-block ${className || ''}`}
+      style={{ width, height }}
+    >
+      <div className="absolute h-full w-full">
+        <SvgShape width={width} height={height} />
+      </div>
+
+      <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center pl-4 pr-7">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const SvgShape: React.FC<{ width: number; height: number }> = ({
+  width,
+  height,
+}) => {
+  const id = useId();
+  const pathData = `
+    M0 4.875
+    C0 2.666, 1.791 0.875, 4 0.875 H${width - 4.131}
+    C${width - 0.811} 0.875, ${width + 1.064} 4.686, ${width - 0.962} 7.316
+    L${width - 17.231} 28.434 C${width - 18.339} 29.873, ${width - 18.339} 31.878, ${width - 17.231} 33.317
+    L${width - 0.962} 54.434 C${width + 1.064} 57.064, ${width - 0.811} 60.875, ${width - 4.131} 60.875
+    H4 C1.791 60.875, 0 59.085, 0 56.875 V4.875 Z
+  `;
+  const gradientId = `grad_${id}`;
+
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${width} ${height}`}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d={pathData} fill={`url(#${gradientId})`} />
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="0"
+          y1={height / 2}
+          x2={width}
+          y2={height / 2}
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FFE7A8" />
+          <stop offset="0.322" stopColor="#FFDD85" />
+          <stop offset="1" stopColor="#FECD4C" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};

--- a/src/page/TimerPage/components/TimerView.tsx
+++ b/src/page/TimerPage/components/TimerView.tsx
@@ -3,6 +3,7 @@ import { TimerPageLogics } from '../hooks/useTimerPageState';
 import NormalTimer from './NormalTimer';
 import TimeBasedTimer from './TimeBasedTimer';
 import { FaExchangeAlt } from 'react-icons/fa';
+import TimeBasedTimerTitle from './TimeBasedTimerTitle';
 
 export default function TimerView({ state }: { state: TimerPageLogics }) {
   const {
@@ -43,47 +44,56 @@ export default function TimerView({ state }: { state: TimerPageLogics }) {
   }
   if (data?.table[index]?.boxType === 'TIME_BASED') {
     return (
-      <div className="relative flex flex-row items-center justify-center space-x-[30px]">
-        {/* 왼쪽 타이머 */}
-        <TimeBasedTimer
-          timeBasedTimerInstance={{
-            totalTimer: timer1.totalTimer,
-            speakingTimer: timer1.speakingTimer,
-            isRunning: timer1.isRunning,
-            startTimer: timer1.startTimer,
-            pauseTimer: timer1.pauseTimer,
-            resetCurrentTimer: timer1.resetCurrentTimer,
-          }}
-          isSelected={prosConsSelected === 'PROS'}
-          onActivate={() => handleActivateTeam('PROS')}
-          prosCons="PROS"
-          teamName={data.info.prosTeamName}
-        />
-        {/* 오른쪽 타이머 */}
-        <TimeBasedTimer
-          timeBasedTimerInstance={{
-            totalTimer: timer2.totalTimer,
-            speakingTimer: timer2.speakingTimer,
-            isRunning: timer2.isRunning,
-            startTimer: timer2.startTimer,
-            pauseTimer: timer2.pauseTimer,
-            resetCurrentTimer: timer2.resetCurrentTimer,
-          }}
-          isSelected={prosConsSelected === 'CONS'}
-          onActivate={() => handleActivateTeam('CONS')}
-          prosCons="CONS"
-          teamName={data.info.consTeamName}
-        />
-        {/* ENTER 버튼 */}
-        <button
-          onClick={switchCamp}
-          className="absolute left-1/2 top-1/2 flex h-[78px] w-[78px] -translate-x-[70px] -translate-y-6 flex-col items-center justify-center rounded-full bg-neutral-600 text-white shadow-lg transition hover:bg-neutral-500 lg:h-[100px] lg:w-[100px] lg:-translate-x-20 lg:-translate-y-8"
-        >
-          <FaExchangeAlt className="text-[28px] lg:text-[36px]" />
-          <span className="text-[12px] font-semibold lg:text-[18px] lg:font-bold">
-            ENTER
-          </span>
-        </button>
+      <div className="flex flex-col space-y-12">
+        {/* 현재 순서 제목 */}
+        <TimeBasedTimerTitle>
+          <h1 className="truncate text-[32px] font-bold text-neutral-900">
+            {data.table[index].speechType}
+          </h1>
+        </TimeBasedTimerTitle>
+
+        <div className="relative flex flex-row items-center justify-center space-x-[30px]">
+          {/* 왼쪽 타이머 */}
+          <TimeBasedTimer
+            timeBasedTimerInstance={{
+              totalTimer: timer1.totalTimer,
+              speakingTimer: timer1.speakingTimer,
+              isRunning: timer1.isRunning,
+              startTimer: timer1.startTimer,
+              pauseTimer: timer1.pauseTimer,
+              resetCurrentTimer: timer1.resetCurrentTimer,
+            }}
+            isSelected={prosConsSelected === 'PROS'}
+            onActivate={() => handleActivateTeam('PROS')}
+            prosCons="PROS"
+            teamName={data.info.prosTeamName}
+          />
+          {/* 오른쪽 타이머 */}
+          <TimeBasedTimer
+            timeBasedTimerInstance={{
+              totalTimer: timer2.totalTimer,
+              speakingTimer: timer2.speakingTimer,
+              isRunning: timer2.isRunning,
+              startTimer: timer2.startTimer,
+              pauseTimer: timer2.pauseTimer,
+              resetCurrentTimer: timer2.resetCurrentTimer,
+            }}
+            isSelected={prosConsSelected === 'CONS'}
+            onActivate={() => handleActivateTeam('CONS')}
+            prosCons="CONS"
+            teamName={data.info.consTeamName}
+          />
+          {/* ENTER 버튼 */}
+          <button
+            onClick={switchCamp}
+            className="absolute left-1/2 top-1/2 flex h-[78px] w-[78px] -translate-x-[70px] -translate-y-6 flex-col items-center justify-center rounded-full bg-neutral-600 text-white shadow-lg transition hover:bg-neutral-500 lg:h-[100px] lg:w-[100px] lg:-translate-x-20 lg:-translate-y-8"
+          >
+            <FaExchangeAlt className="text-[28px] lg:text-[36px]" />
+            <span className="text-[12px] font-semibold lg:text-[18px] lg:font-bold">
+              ENTER
+            </span>
+          </button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #19 

# 📝 작업 내용
## 문제 상황
시간 총량제 타이머가 2개 이상 연속되는 경우, 현재 차례가 무엇읹 식별 불가능한 문제가 있었음

## 개선 사항
- 시간 총량제 타이머 제목 추가
- 타이머가 잘리지 않게 높이 조정

# 🏞️ 스크린샷 (선택)
## 시간 총량제 제목을 적용한 864 px 높이의 화면
타이머가 잘리지 않고 스크롤 바가 생기지 않는 것을 확인 가능

<img width="1266" height="857" alt="image" src="https://github.com/user-attachments/assets/5303a4ed-2362-4230-baeb-cb6169e048e2" />

# 🗣️ 리뷰 요구사항 (선택)
이 PR은 debate-timer-fe 저장소의 [PR 318](https://github.com/debate-timer/debate-timer-fe/pull/318)에서 승인된 바 있기 때문에, 이 저장소에서는 별도 리뷰 없이 병합합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 타이머 페이지 상단에 현재 연설 유형을 보여주는 시각적 타이틀이 추가되었습니다.

* **스타일**
  * 타이머 창의 기본 및 최소 높이가 1080픽셀에서 864픽셀로 조정되어 더 작은 화면에서도 사용이 편리해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->